### PR TITLE
ログイン判定の修正案１

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,41 +1,46 @@
-import Link from 'next/link'
-import { useRecoilState} from 'recoil';
-import PersonIcon from '@mui/icons-material/Person';
+import Link from "next/link";
+import { useRecoilState, useRecoilValue } from "recoil";
+import PersonIcon from "@mui/icons-material/Person";
 
-import HeaderModal from './HeaderModal';
-import { modalShowState } from '../src/status/modalShowState';
-import styles from '../styles/Header.module.css'
-
+import HeaderModal from "./HeaderModal";
+import { modalShowState } from "../src/status/modalShowState";
+import styles from "../styles/Header.module.css";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useAuth, userAuthState } from "../src/store/auth";
 
 const Header = () => {
   // ヘッダーのモーダルの値をrecoilで管理
-  const[modalShow, setModalShow] = useRecoilState(modalShowState);
+  const [modalShow, setModalShow] = useRecoilState(modalShowState);
+  const router = useRouter();
+  const userAuth = useRecoilValue(userAuthState)
+
+  useEffect(() => {
+    if (userAuth) return;
+    router.push("/login");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userAuth]);
 
   return (
     <>
       <div className={styles.header}>
         <div className={styles.header_icon}>
-          <Link href={"/"}>
-            TODO
-          </Link>
+          <Link href={"/"}>TODO</Link>
         </div>
-        <div 
-          className={styles.header_profile_icon} 
-          onClick={() => setModalShow(!modalShow)}
-        >
-          <PersonIcon 
+        <div className={styles.header_profile_icon} onClick={() => setModalShow(!modalShow)}>
+          <PersonIcon
             style={{
-              backgroundColor: "black", 
-              color: "white", 
-              fontSize:"25px", 
-              borderRadius:"20px"
+              backgroundColor: "black",
+              color: "white",
+              fontSize: "25px",
+              borderRadius: "20px",
             }}
           />
         </div>
       </div>
       <HeaderModal modalShow={modalShow} />
     </>
-  )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/components/HeaderModal.tsx
+++ b/components/HeaderModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router';
-import { useRecoilState} from 'recoil';
+import { useRecoilState, useSetRecoilState} from 'recoil';
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import { getAuth, signOut } from 'firebase/auth';
 
@@ -12,6 +12,7 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import { db, firebaseApp} from '../src/store/firebase';
 import { profileState } from '../src/status/profileState';
 import styles from '../styles/Header.module.css'
+import { userAuthState } from '../src/store/auth';
 
 
 type Props = {
@@ -22,6 +23,7 @@ type Props = {
 const HeaderModal = ({modalShow}:Props) => {
   const router = useRouter();
   const auth = getAuth(firebaseApp);
+  const setUserAuth = useSetRecoilState(userAuthState)
 
   // プロフィール情報をuseRecoilで管理
   const [profile, setProfile] = useRecoilState<any>(profileState)
@@ -80,7 +82,8 @@ const HeaderModal = ({modalShow}:Props) => {
   // ログアウトする関数
   const handleLogout = async () => {
     await signOut(auth)
-    await router.push("/login")
+    setUserAuth(false)
+    router.push("/login")
   };
   
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,26 +1,19 @@
-import { RecoilRoot } from 'recoil'
-import type { AppProps } from 'next/app'
-import { ChakraProvider } from '@chakra-ui/react'
-import { useAuth } from '../src/store/auth'
-import '../styles/globals.css'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
-
+import { RecoilRoot } from "recoil";
+import type { AppProps } from "next/app";
+import { ChakraProvider } from "@chakra-ui/react";
+import { useAuth } from "../src/store/auth";
+import "../styles/globals.css";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 type Props = {
   children: JSX.Element;
-}
-
-const Auth = ({children}: Props): JSX.Element => {
-  const {isLoading, user} = useAuth();
-  const router = useRouter();
-  useEffect(() => {
-    if (user) return;
-    router.push("/login")
-  },[])
-  return isLoading ? <p>Loading...</p> : children;
 };
 
+const Auth = ({ children }: Props): JSX.Element => {
+  const { isLoading } = useAuth();
+  return isLoading ? <p>Loading...</p> : children;
+};
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -31,5 +24,5 @@ export default function App({ Component, pageProps }: AppProps) {
         </ChakraProvider>
       </Auth>
     </RecoilRoot>
-  )
+  );
 }

--- a/pages/add_todo.tsx
+++ b/pages/add_todo.tsx
@@ -6,7 +6,7 @@ import Header from '../components/Header'
 import { modalShowState } from '../src/status/modalShowState';
 
 
-const add_todo = () => {
+const AddTodo = () => {
   // 別の場所をクリックしてもモーダルウィンドウを閉じる
   const[modalShow, setModalShow] = useRecoilState(modalShowState);
   const closeModalShow = () => {
@@ -22,4 +22,4 @@ const add_todo = () => {
   )
 }
 
-export default add_todo
+export default AddTodo

--- a/pages/detail_todo.tsx
+++ b/pages/detail_todo.tsx
@@ -22,7 +22,7 @@ type ToEditInfo = {
 }
 
 
-const detail_todo = () => {
+const DetailTodo = () => {
   const router = useRouter();
   // 編集ページに渡すprops
   const toEditInfo:ToEditInfo = {
@@ -184,4 +184,4 @@ const detail_todo = () => {
   )
 }
 
-export default detail_todo
+export default DetailTodo

--- a/pages/edit_todo.tsx
+++ b/pages/edit_todo.tsx
@@ -5,7 +5,7 @@ import EditInputForm from '../components/EditInputform'
 import Header from '../components/Header'
 import { modalShowState } from '../src/status/modalShowState';
 
-const edit_todo = () => {
+const EditTodo = () => {
   // 別の場所をクリックしてもモーダルウィンドウを閉じる
   const[modalShow, setModalShow] = useRecoilState(modalShowState);
   const closeModalShow = () => {
@@ -22,4 +22,4 @@ const edit_todo = () => {
   )
 }
 
-export default edit_todo
+export default EditTodo

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -7,13 +7,16 @@ import { Box, Button, Center, FormLabel, Input, Text, Grid, GridItem } from '@ch
 
 import styles from '../styles/login.module.css'
 import { firebaseApp } from '../src/store/firebase'
+import { useSetRecoilState } from 'recoil'
+import { userAuthState } from '../src/store/auth'
 
 
-const login = () => {
+const Login = () => {
   const router = useRouter();
   const auth = getAuth();
 
   const [error, setError] = useState('');
+  const setUserAuth = useSetRecoilState(userAuthState)
 
   // emailでログインするための関数
   const handleEmailLogin = async(event: any) => {
@@ -21,6 +24,7 @@ const login = () => {
     const { email, password } = event.currentTarget.elements;
     signInWithEmailAndPassword(auth, email.value, password.value)
     .then((user) => {
+      setUserAuth(user.user.uid !== "")
       router.push("/")
       console.log('ログイン成功=', user.user.uid)
     })
@@ -46,9 +50,9 @@ const login = () => {
   const handleGoogleLogin = async(event: any) => {
     event.preventDefault();
     const provider = new GoogleAuthProvider();
-    const auth = getAuth(firebaseApp);
     signInWithPopup(auth, provider)
     .then((result) => {
+      setUserAuth(result.user.uid !== "")
       router.push("/")
       console.log('ログイン成功=', result.user.uid)
     }).catch((error) => {
@@ -147,4 +151,4 @@ const login = () => {
   )
 }
 
-export default login
+export default Login

--- a/pages/setting.tsx
+++ b/pages/setting.tsx
@@ -23,7 +23,7 @@ const MyEditIcon = styled(EditIcon)({
 })
 
 
-const setting: React.FC  = () => {
+const Setting: React.FC  = () => {
   // recoilで管理しているプロフィール情報を読み取って関数に設定
   const profile = useRecoilValue<any>(profileState);
 
@@ -81,4 +81,4 @@ const setting: React.FC  = () => {
   )
 }
 
-export default setting
+export default Setting

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -7,7 +7,7 @@ import {  FormLabel, Input, Button, Text, Box, Center } from '@chakra-ui/react'
 
 import styles from '../styles/signup.module.css'
 
-const signup = () => {
+const Signup = () => {
   const auth = getAuth();
   const router = useRouter();
 
@@ -82,4 +82,4 @@ const signup = () => {
   )
 } 
 
-export default signup
+export default Signup

--- a/src/store/auth.tsx
+++ b/src/store/auth.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { atom, useRecoilState, useSetRecoilState  } from "recoil";
+import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { User, getAuth, onAuthStateChanged } from "firebase/auth";
-import { firebaseApp } from "./firebase";
-import 'firebase/auth'
+import { auth, firebaseApp } from "./firebase";
+import "firebase/auth";
 
 type UserState = User | null;
 
@@ -12,18 +12,27 @@ const userState = atom<UserState>({
   dangerouslyAllowMutability: true,
 });
 
+export const userAuthState = atom<boolean>({
+  key: "userAuthState",
+  default: false,
+})
+
 export const useAuth = () => {
   const [isLoading, setIsLoading] = useState(true);
-  const [user, setUser] = useRecoilState(userState);
+  const setUser = useSetRecoilState(userState);
+  const setUserAuth = useSetRecoilState(userAuthState);
 
   useEffect(() => {
-    const auth = getAuth(firebaseApp);
-    return onAuthStateChanged(auth, async (user) => {
+    onAuthStateChanged(auth, async (user) => {
+      if (user === null) return
+      setUserAuth(user.uid !== "")
       setUser(user);
       setIsLoading(false);
-    })
+    });
+    setIsLoading(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  return {isLoading, user};
+  return { isLoading };
 };
 
 // export const useUser = (): UserState => {


### PR DESCRIPTION
## 課題
- リロードした時にもログイン判定を行う
- ログイン済みの場合はそのままのページを表示する
- 未ログインの場合はログイン画面に遷移する

## 変更内容
- _app.tsxにあるAuthは画面をロード時に呼ばれ、ページ遷移時には呼ばれない
- `src/store/auth.tsx`にてRecoilでログイン状態を判定するuserAuthStateを定義
- ログイン後にuserAuthStateをtrueにするように変更
- ログアウト後にuserAuthStateをfalseにするように変更